### PR TITLE
Add reverse proxy for testing obos with local instance of gatekeeper

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -6,4 +6,4 @@ COPY hiss /app
 
 RUN python3 -m pip install -r requirements.txt
 
-CMD python3 manage.py runserver 127.0.0.1:$PORT
+CMD python3 manage.py runserver 0.0.0.0:$PORT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,16 @@ services:
       POSTGRES_PASSWORD: dev_password
     ports:
      - "5432:5432"
+  proxy:
+    image: nginx
+    depends_on:
+      - web
+    volumes:
+      - ./routes.conf:/etc/nginx/conf.d/default.conf
+    ports:
+      - "8080:8080"
+    expose:
+      - 8080
   web:
     build:
       context: .

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,9 +15,14 @@ services:
     volumes:
       - ./routes.conf:/etc/nginx/conf.d/default.template
     environment:
-      BASE_PATHNAME: apply
+      GATEKEEPER_BASE_PATHNAME: auth
+      GATEKEEPER_HOSTNAME: host.docker.internal:3000  # keep in mind host.docker.internal doesn't work on docker for linux
+
+      OBOS_BASE_PATHNAME: apply
+      OBOS_HOSTNAME: web:8000
+
       PORT: 8080
-    command: /bin/bash -c "envsubst '$$BASE_PATHNAME $$PORT' < /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'" 
+    command: /bin/bash -c "envsubst '$$GATEKEEPER_BASE_PATHNAME $$GATEKEEPER_HOSTNAME $$OBOS_BASE_PATHNAME $$OBOS_HOSTNAME $$PORT' < /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'" 
     tty: true
     ports:
       - "8080:8080"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,12 @@ services:
     depends_on:
       - web
     volumes:
-      - ./routes.conf:/etc/nginx/conf.d/default.conf
+      - ./routes.conf:/etc/nginx/conf.d/default.template
+    environment:
+      BASE_PATHNAME: apply
+      PORT: 8080
+    command: /bin/bash -c "envsubst '$$BASE_PATHNAME $$PORT' < /etc/nginx/conf.d/default.template > /etc/nginx/conf.d/default.conf && nginx -g 'daemon off;'" 
+    tty: true
     ports:
       - "8080:8080"
     expose:
@@ -31,6 +36,7 @@ services:
     environment:
       PORT: 8000
       DATABASE_URL: postgres://postgres:dev_password@db:5432/hiss
+      BASE_PATHNAME: apply
     expose:
       - 8000
       

--- a/hiss/hiss/settings/base.py
+++ b/hiss/hiss/settings/base.py
@@ -20,7 +20,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
  
 # Base Pathname for Obos (when not being hosted at root)
 BASE_PATHNAME = os.environ.get("BASE_PATHNAME") if os.environ.get("BASE_PATHNAME") else ""
-BASE_PATHNAME_REGEX = r"apply/$"
+BASE_PATHNAME_REGEX = BASE_PATHNAME + r"/$"
 
 if len(BASE_PATHNAME) > 0:
     BASE_PATHNAME += '/'

--- a/hiss/hiss/settings/base.py
+++ b/hiss/hiss/settings/base.py
@@ -18,6 +18,9 @@ import dj_database_url
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
+# Base Pathname for Obos (in galaxy)
+FORCE_SCRIPT_NAME = '/apply'
+
 # Application definition
 INSTALLED_APPS = [
     "django.contrib.admin",
@@ -99,7 +102,8 @@ LOGOUT_REDIRECT_URL = reverse_lazy("customauth:login")
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
 
-STATIC_URL = "/static/"
+# Changed to include path prefix (for galaxy)
+STATIC_URL = FORCE_SCRIPT_NAME + "/static/"
 STATICFILES_DIRS = [os.path.join(BASE_DIR, "..", "static/")]
 STATIC_ROOT = "public/"
 APPEND_SLASH = True

--- a/hiss/hiss/settings/base.py
+++ b/hiss/hiss/settings/base.py
@@ -17,10 +17,13 @@ import dj_database_url
 
 # Build paths inside the project like this: os.path.join(BASE_DIR, ...)
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
-
-# Base Pathname for Obos (in galaxy)
-BASE_PATHNAME = 'apply/'
+ 
+# Base Pathname for Obos (when not being hosted at root)
+BASE_PATHNAME = os.environ.get("BASE_PATHNAME") if os.environ.get("BASE_PATHNAME") else ""
 BASE_PATHNAME_REGEX = r"apply/$"
+
+if len(BASE_PATHNAME) > 0:
+    BASE_PATHNAME += '/'
 
 # Application definition
 INSTALLED_APPS = [

--- a/hiss/hiss/settings/base.py
+++ b/hiss/hiss/settings/base.py
@@ -19,7 +19,8 @@ import dj_database_url
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
 # Base Pathname for Obos (in galaxy)
-FORCE_SCRIPT_NAME = '/apply'
+BASE_PATHNAME = 'apply/'
+BASE_PATHNAME_REGEX = r"apply/$"
 
 # Application definition
 INSTALLED_APPS = [
@@ -102,8 +103,7 @@ LOGOUT_REDIRECT_URL = reverse_lazy("customauth:login")
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/2.2/howto/static-files/
 
-# Changed to include path prefix (for galaxy)
-STATIC_URL = FORCE_SCRIPT_NAME + "/static/"
+STATIC_URL = "/" + BASE_PATHNAME + "static/"
 STATICFILES_DIRS = [os.path.join(BASE_DIR, "..", "static/")]
 STATIC_ROOT = "public/"
 APPEND_SLASH = True

--- a/hiss/hiss/urls.py
+++ b/hiss/hiss/urls.py
@@ -27,12 +27,12 @@ def healthcheck(request):
 
 
 urlpatterns = [
-    path("admin/", admin.site.urls),
-    path("accounts/", include("customauth.urls")),
-    path("application/", include("application.urls", namespace="application")),
-    path("healthy/", healthcheck),
-    url(r"^$", RedirectView.as_view(pattern_name="customauth:login")),
-    path("status/", include("status.urls")),
-    path("team/", include("team.urls")),
-    path("api/volunteer/", include("volunteer.urls")),
+    path(settings.BASE_PATHNAME + "admin/", admin.site.urls),
+    path(settings.BASE_PATHNAME + "accounts/", include("customauth.urls")),
+    path(settings.BASE_PATHNAME + "application/", include("application.urls", namespace="application")),
+    path(settings.BASE_PATHNAME + "healthy/", healthcheck),
+    url(settings.BASE_PATHNAME_REGEX, RedirectView.as_view(pattern_name="customauth:login")),
+    path(settings.BASE_PATHNAME + "status/", include("status.urls")),
+    path(settings.BASE_PATHNAME + "team/", include("team.urls")),
+    path(settings.BASE_PATHNAME + "api/volunteer/", include("volunteer.urls")),
 ] + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/routes.conf
+++ b/routes.conf
@@ -1,0 +1,18 @@
+server {
+	listen 8080;
+	
+	location /auth/ {
+		proxy_pass 		   http://host.docker.internal:3000/;
+		proxy_set_header Host "localhost:3000";
+	}
+
+	location /apply/ {
+		# obos is setup in hiss/settings/base.py to have /apply as its base route
+		proxy_pass 		   http://web:8000/;
+		proxy_set_header Host "localhost:8000";
+	}
+
+	location / {
+		proxy_pass	https://gigabowser.now.sh/;
+	}
+}

--- a/routes.conf
+++ b/routes.conf
@@ -1,15 +1,15 @@
 server {
 	listen ${PORT};
 	
-	location /auth/ {
-		proxy_pass            http://host.docker.internal:3000/;
-		proxy_set_header      Host "localhost:3000";
+	location /${GATEKEEPER_BASE_PATHNAME}/ {
+		proxy_pass            http://${GATEKEEPER_HOSTNAME}/;
+		proxy_set_header      Host "localhost";
 	}
 
-	location /${BASE_PATHNAME} {
+	location /${OBOS_BASE_PATHNAME} {
 		# obos is setup in hiss/settings/base.py to have /${BASE_PATHNAME} as its base route
-		proxy_pass 		        http://web:8000;
-		proxy_set_header Host   "localhost:8000";
+		proxy_pass 	            http://${OBOS_HOSTNAME};
+		proxy_set_header        Host "localhost";
 	}
 
 	location / {

--- a/routes.conf
+++ b/routes.conf
@@ -1,15 +1,15 @@
 server {
-	listen 8080;
+	listen ${PORT};
 	
 	location /auth/ {
-		proxy_pass 		   http://host.docker.internal:3000/;
-		proxy_set_header Host "localhost:3000";
+		proxy_pass            http://host.docker.internal:3000/;
+		proxy_set_header      Host "localhost:3000";
 	}
 
-	location /apply {
-		# obos is setup in hiss/settings/base.py to have /apply as its base route
-		proxy_pass 		   http://web:8000;
-		proxy_set_header Host "localhost:8000";
+	location /${BASE_PATHNAME} {
+		# obos is setup in hiss/settings/base.py to have /${BASE_PATHNAME} as its base route
+		proxy_pass 		        http://web:8000;
+		proxy_set_header Host   "localhost:8000";
 	}
 
 	location / {

--- a/routes.conf
+++ b/routes.conf
@@ -6,9 +6,9 @@ server {
 		proxy_set_header Host "localhost:3000";
 	}
 
-	location /apply/ {
+	location /apply {
 		# obos is setup in hiss/settings/base.py to have /apply as its base route
-		proxy_pass 		   http://web:8000/;
+		proxy_pass 		   http://web:8000;
 		proxy_set_header Host "localhost:8000";
 	}
 


### PR DESCRIPTION
- Adds nginx as a reverse proxy
- To access the "galaxy" just go to localhost:8080
   - http://localhost:8080/auth/ points to http://localhost:3000/
   - http://localhost:8080/apply/ points to http://web:8000/apply
- Redirects to gatekeeper are not done in this pr
- But the static files and such are proxied correctly